### PR TITLE
#225 Reset only local traces at the end of launchers to avoid resetti…

### DIFF
--- a/sources/Launcher/DYNMarginCalculationLauncher.cpp
+++ b/sources/Launcher/DYNMarginCalculationLauncher.cpp
@@ -789,7 +789,7 @@ MarginCalculationLauncher::launchLoadIncrease(const boost::shared_ptr<LoadIncrea
 void
 MarginCalculationLauncher::createOutputs(std::map<std::string, std::string>& mapData, bool zipIt) const {
   Trace::resetCustomAppenders();  // to force flush
-  Trace::resetPersistantCustomAppenders();  // to force flush
+  Trace::resetPersistantCustomAppender(logTag_, DYN::INFO);  // to force flush
   aggregatedResults::XmlExporter exporter;
   if (zipIt) {
     std::stringstream aggregatedResults;

--- a/sources/Launcher/DYNRobustnessAnalysisLauncher.cpp
+++ b/sources/Launcher/DYNRobustnessAnalysisLauncher.cpp
@@ -426,7 +426,7 @@ RobustnessAnalysisLauncher::simulate(const boost::shared_ptr<DYN::Simulation>& s
 void
 RobustnessAnalysisLauncher::storeOutputs(const SimulationResult& result, std::map<std::string, std::string>& mapData) const {
   Trace::resetCustomAppenders();  // to force flush
-  Trace::resetPersistantCustomAppenders();  // to force flush
+  Trace::resetPersistantCustomAppender(logTag_, DYN::INFO);  // to force flush
   if (!result.getTimelineStreamStr().empty()) {
     std::stringstream timelineName;
     timelineName << "timeLine/timeline_" << result.getUniqueScenarioId() << "." << result.getTimelineFileExtension();
@@ -452,7 +452,7 @@ RobustnessAnalysisLauncher::storeOutputs(const SimulationResult& result, std::ma
 void
 RobustnessAnalysisLauncher::writeOutputs(const SimulationResult& result) const {
   Trace::resetCustomAppenders();  // to force flush
-  Trace::resetPersistantCustomAppenders();  // to force flush
+  Trace::resetPersistantCustomAppender(logTag_, DYN::INFO);  // to force flush
   std::string constraintPath = createAbsolutePath("constraints", workingDirectory_);
   if (!is_directory(constraintPath))
     create_directory(constraintPath);


### PR DESCRIPTION
…ng upper project traces

closes #225

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of algorithms)
- [ ] main documentation was updated (update of input/output file, update of algorithms)
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
- [x] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
