### PR TITLE
#327 Avoid writing output files not used and harmonize lost equipment…

### DIFF
--- a/sources/Common/DYNSimulationResult.cpp
+++ b/sources/Common/DYNSimulationResult.cpp
@@ -28,7 +28,8 @@ SimulationResult::SimulationResult():
     success_(false),
     status_(EXECUTION_PROBLEM_STATUS),
     timelineFileExtension_("xml"),
-    constraintsFileExtension_("xml") {
+    constraintsFileExtension_("xml"),
+    lostEquipmentsFileExtension_("xml") {
 }
 
 SimulationResult::~SimulationResult() {
@@ -42,9 +43,11 @@ SimulationResult::SimulationResult(const SimulationResult& result):
     failingCriteria_(result.failingCriteria_),
     timelineFileExtension_(result.timelineFileExtension_),
     constraintsFileExtension_(result.constraintsFileExtension_),
+    lostEquipmentsFileExtension_(result.lostEquipmentsFileExtension_),
     logPath_(result.logPath_) {
   timelineStream_ << result.timelineStream_.str();
   constraintsStream_ << result.constraintsStream_.str();
+  lostEquipmentsStream_ << result.lostEquipmentsStream_.str();
 }
 
 SimulationResult&
@@ -60,6 +63,9 @@ SimulationResult::operator=(const SimulationResult& result) {
   constraintsStream_.str("");
   constraintsStream_.clear();
   constraintsStream_ << result.constraintsStream_.str();
+  lostEquipmentsStream_.str("");
+  lostEquipmentsStream_.clear();
+  lostEquipmentsStream_ << result.lostEquipmentsStream_.str();
   failingCriteria_ = result.failingCriteria_;
   timelineFileExtension_ = result.timelineFileExtension_;
   constraintsFileExtension_ =  result.constraintsFileExtension_;
@@ -106,6 +112,16 @@ SimulationResult::getConstraintsStream() {
 std::string
 SimulationResult::getConstraintsStreamStr() const {
   return constraintsStream_.str();
+}
+
+std::stringstream&
+SimulationResult::getLostEquipementsStream() {
+  return lostEquipmentsStream_;
+}
+
+std::string
+SimulationResult::getLostEquipementsStreamStr() const {
+  return lostEquipmentsStream_.str();
 }
 
 std::string
@@ -160,7 +176,7 @@ SimulationResult::getConstraintsFileExtension() const {
 }
 
 void
-SimulationResult::setConstraintsFileExtensionFromExportMode(const std::string &constraintsExportMode) {
+SimulationResult::setConstraintsFileExtensionFromExportMode(const std::string& constraintsExportMode) {
   if (constraintsExportMode == "XML")
     constraintsFileExtension_ = "xml";
   else if (constraintsExportMode == "TXT")
@@ -168,7 +184,7 @@ SimulationResult::setConstraintsFileExtensionFromExportMode(const std::string &c
 }
 
 void
-SimulationResult::setConstraintsFileExtension(const std::string &constraintsFileExtension) {
+SimulationResult::setConstraintsFileExtension(const std::string& constraintsFileExtension) {
   constraintsFileExtension_ = constraintsFileExtension;
 }
 
@@ -178,7 +194,7 @@ SimulationResult::getTimelineFileExtension() const {
 }
 
 void
-SimulationResult::setTimelineFileExtensionFromExportMode(const std::string &timelineExportMode) {
+SimulationResult::setTimelineFileExtensionFromExportMode(const std::string& timelineExportMode) {
   if (timelineExportMode == "XML")
     timelineFileExtension_ = "xml";
   else if (timelineExportMode == "TXT")
@@ -190,6 +206,22 @@ SimulationResult::setTimelineFileExtensionFromExportMode(const std::string &time
 void
 SimulationResult::setTimelineFileExtension(const std::string &timelineFileExtension) {
   timelineFileExtension_ = timelineFileExtension;
+}
+
+const std::string&
+SimulationResult::getLostEquipmentsFileExtension() const {
+  return lostEquipmentsFileExtension_;
+}
+
+void
+SimulationResult::setLostEquipmentsFileExtensionFromExportMode(const std::string& lostEquipmentsExportMode) {
+  if (lostEquipmentsExportMode == "XML")
+    timelineFileExtension_ = "xml";
+}
+
+void
+SimulationResult::setLostEquipmentsFileExtension(const std::string& lostEquipmentsFileExtension) {
+  lostEquipmentsFileExtension_ = lostEquipmentsFileExtension;
 }
 
 const std::string&

--- a/sources/Common/DYNSimulationResult.h
+++ b/sources/Common/DYNSimulationResult.h
@@ -108,6 +108,18 @@ class SimulationResult {
   std::string getConstraintsStreamStr() const;
 
   /**
+   * @brief getter of the lost equipments stream associated to the scenario
+   * @return lost equipments stream associated to the scenario
+   */
+  std::stringstream& getLostEquipementsStream();
+
+  /**
+   * @brief getter of the lost equipments associated to the scenario
+   * @return lost equipments associated to the scenario
+   */
+  std::string getLostEquipementsStreamStr() const;
+
+  /**
    * @brief getter of the scenario id associated to the simulation
    * @return the scenario id associated to the simulation
    */
@@ -168,13 +180,13 @@ class SimulationResult {
    * @brief setter of the constraints file extension based on constraints export mode from the job
    * @param constraintsExportMode constraints export mode
    */
-  void setConstraintsFileExtensionFromExportMode(const std::string &constraintsExportMode);
+  void setConstraintsFileExtensionFromExportMode(const std::string& constraintsExportMode);
 
   /**
    * @brief setter of the constraints file extension
    * @param constraintsFileExtension constraints export mode
    */
-  void setConstraintsFileExtension(const std::string &constraintsFileExtension);
+  void setConstraintsFileExtension(const std::string& constraintsFileExtension);
 
   /**
    * @brief getter of the timeline file extension
@@ -195,6 +207,24 @@ class SimulationResult {
   void setTimelineFileExtension(const std::string &timelineFileExtension);
 
   /**
+   * @brief getter of the lost equipments file extension
+   * @return lost equipments file extension
+   */
+  const std::string& getLostEquipmentsFileExtension() const;
+
+  /**
+   * @brief setter of the lost equipments file extension based on lost equipments export mode from the job
+   * @param lostEquipmentsExportMode lost equipments export mode
+   */
+  void setLostEquipmentsFileExtensionFromExportMode(const std::string& lostEquipmentsExportMode);
+
+  /**
+   * @brief setter of the lost equipments file extension
+   * @param constraintsFileExtension lost equipments export mode
+   */
+  void setLostEquipmentsFileExtension(const std::string& lostEquipmentsFileExtension);
+
+  /**
    * @brief getter of the general dynawo log path
    * @return general dynawo log path
    */
@@ -209,6 +239,7 @@ class SimulationResult {
  private:
   std::stringstream timelineStream_;  ///< stream for the timeline associated to the scenario
   std::stringstream constraintsStream_;  ///< stream for the constraints associated to the scenario
+  std::stringstream lostEquipmentsStream_;  ///< stream for the lost equipments associated to the scenario
   std::string scenarioId_;  ///< id of the scenario
   double variation_;  ///< variation of the scenario (aka loadLevel when associated to a load increase)
   bool success_;  ///< @b true if the simulation reached its end, @b false otherwise
@@ -216,6 +247,7 @@ class SimulationResult {
   std::vector<std::pair<double, std::string> > failingCriteria_;  ///< failing criteria ids
   std::string timelineFileExtension_;  ///< timeline export mode for this result
   std::string constraintsFileExtension_;  ///< constraints export mode for this result
+  std::string lostEquipmentsFileExtension_;  ///< lost equipments export mode for this result
   std::string logPath_;   ///< Path to the general dynawo log file associated to this result
 };
 

--- a/sources/Launcher/DYNSystematicAnalysisLauncher.cpp
+++ b/sources/Launcher/DYNSystematicAnalysisLauncher.cpp
@@ -127,6 +127,9 @@ SystematicAnalysisLauncher::launchScenario(const boost::shared_ptr<Scenario>& sc
   SimulationResult result;
   result.setScenarioId(scenario->getId());
   boost::shared_ptr<DYN::Simulation> simulation = createAndInitSimulation(workingDir, job, params, result, inputs_);
+  simulation->setTimelineOutputFile("");
+  simulation->setConstraintsOutputFile("");
+  simulation->setLostEquipmentsOutputFile("");
 
   if (simulation) {
     simulate(simulation, result);


### PR DESCRIPTION
…s with other outputs.

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of algorithms)
- [ ] main documentation was updated (update of input/output file, update of algorithms)
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
- [ ] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
