### PR TITLE
#327 Fix wrong attirbute set and harmonize extension for txt to log a…

### DIFF
--- a/sources/Common/DYNSimulationResult.cpp
+++ b/sources/Common/DYNSimulationResult.cpp
@@ -180,7 +180,7 @@ SimulationResult::setConstraintsFileExtensionFromExportMode(const std::string& c
   if (constraintsExportMode == "XML")
     constraintsFileExtension_ = "xml";
   else if (constraintsExportMode == "TXT")
-    constraintsFileExtension_ = "txt";
+    constraintsFileExtension_ = "log";
 }
 
 void
@@ -198,7 +198,7 @@ SimulationResult::setTimelineFileExtensionFromExportMode(const std::string& time
   if (timelineExportMode == "XML")
     timelineFileExtension_ = "xml";
   else if (timelineExportMode == "TXT")
-    timelineFileExtension_ = "txt";
+    timelineFileExtension_ = "log";
   else if (timelineExportMode == "CSV")
     timelineFileExtension_ = "csv";
 }
@@ -216,7 +216,7 @@ SimulationResult::getLostEquipmentsFileExtension() const {
 void
 SimulationResult::setLostEquipmentsFileExtensionFromExportMode(const std::string& lostEquipmentsExportMode) {
   if (lostEquipmentsExportMode == "XML")
-    timelineFileExtension_ = "xml";
+    lostEquipmentsFileExtension_ = "xml";
 }
 
 void

--- a/sources/Launcher/test/TestRobustnessAnalysisLauncher.cpp
+++ b/sources/Launcher/test/TestRobustnessAnalysisLauncher.cpp
@@ -61,7 +61,7 @@ class MyLauncher : public RobustnessAnalysisLauncher {
     writeResults();
     ASSERT_TRUE(exists("res/MyOutputFile.zip"));
     ASSERT_FALSE(exists("res/constraints/constraints_MyScenario.xml"));
-    ASSERT_FALSE(exists("res/timeLine/timeline_MyScenario.txt"));
+    ASSERT_FALSE(exists("res/timeLine/timeline_MyScenario.log"));
     ASSERT_FALSE(exists("res/timeLine/timeline_MyScenario.xml"));
     ASSERT_TRUE(exists("res/logs/log_MyScenario.log"));
 
@@ -71,7 +71,7 @@ class MyLauncher : public RobustnessAnalysisLauncher {
     writeResults();
     ASSERT_TRUE(exists("res/MyOutputFile.zip"));
     ASSERT_TRUE(exists("res/constraints/constraints_MyScenario.xml"));
-    ASSERT_TRUE(exists("res/timeLine/timeline_MyScenario.txt"));
+    ASSERT_TRUE(exists("res/timeLine/timeline_MyScenario.log"));
     ASSERT_FALSE(exists("res/timeLine/timeline_MyScenario.xml"));
     ASSERT_TRUE(exists("res/logs/log_MyScenario.log"));
   }


### PR DESCRIPTION
…s it is in dynawo.

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of algorithms)
- [ ] main documentation was updated (update of input/output file, update of algorithms)
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
- [ ] if this commit targets a release branch: the corresponding milestone was added in the ticket and in this PR
