### PR TITLE
#393 [MC] final load increase logs are not properly chosen when load increase is the only limitation

### DIFF
--- a/sources/Launcher/DYNMarginCalculationLauncher.cpp
+++ b/sources/Launcher/DYNMarginCalculationLauncher.cpp
@@ -896,7 +896,7 @@ MarginCalculationLauncher::createOutputs(std::map<std::string, std::string>& map
           worstResults[scenarioId] = scenarioResult;
       }
     }
-    if (numberOfSuccessfulScenarios == allScenariosResults.size()) {
+    if (loadIncreaseResultIt->getResult().getSuccess() && numberOfSuccessfulScenarios == allScenariosResults.size()) {
       const std::map<std::string, SimulationResult>::const_iterator loadIncreaseBestIt = bestResults.find(LOAD_INCREASE);
       if (loadIncreaseBestIt == bestResults.end() || loadLevel > loadIncreaseBestIt->second.getVariation()) {
         bestResults[LOAD_INCREASE] = loadIncreaseResultIt->getResult();


### PR DESCRIPTION
**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of algorithms)
- [ ] main documentation was updated (update of input/output file, update of algorithms)
- [x] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
