### PR TITLE
#455 some logs are truncated in multi-processing and zip mode

### DIFF
--- a/sources/Launcher/DYNRobustnessAnalysisLauncher.cpp
+++ b/sources/Launcher/DYNRobustnessAnalysisLauncher.cpp
@@ -427,7 +427,6 @@ RobustnessAnalysisLauncher::simulate(const boost::shared_ptr<DYN::Simulation>& s
 
 void
 RobustnessAnalysisLauncher::storeOutputs(const SimulationResult& result, std::map<std::string, std::string>& mapData) const {
-  Trace::resetCustomAppenders();  // to force flush
 #ifndef NDEBUG
   Trace::resetPersistentCustomAppender(logTag_, DYN::DEBUG);  // to force flush
 #else
@@ -545,6 +544,8 @@ RobustnessAnalysisLauncher::writeOutputs(const SimulationResult& result) const {
 
 void
 RobustnessAnalysisLauncher::writeResults() const {
+  multiprocessing::Context::sync();  // To ensure that all procs have finished
+  Trace::resetCustomAppenders();  // to force flush
   if (!multiprocessing::context().isRootProc()) {
     // only main proccessus is performing the archive
     return;


### PR DESCRIPTION
closes #455

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non regression tests were added (update of algorithms)
- [ ] main documentation was updated (update of input/output file, update of algorithms)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
