### PR TITLE
#487 Set the RDMAV_FORK_SAFE variable to avoid interference with dynawo forks

### DIFF
--- a/util/envDynawoAlgorithms.sh
+++ b/util/envDynawoAlgorithms.sh
@@ -196,18 +196,21 @@ set_environnement() {
   # Force build type when building tests (or tests coverage)
   case $1 in
     build-tests-coverage)
+      export RDMAV_FORK_SAFE="1"
       export_var_env_force DYNAWO_BUILD_TYPE=Debug
       export_var_env_force DYNAWO_BUILD_TESTS=OFF
       export_var_env_force DYNAWO_BUILD_TESTS_COVERAGE=ON
       export_var_env_force DYNAWO_USE_XSD_VALIDATION=true
       ;;
     build-tests)
+      export RDMAV_FORK_SAFE="1"
       export_var_env_force DYNAWO_BUILD_TYPE=Debug
       export_var_env_force DYNAWO_BUILD_TESTS=ON
       export_var_env_force DYNAWO_BUILD_TESTS_COVERAGE=OFF
       export_var_env_force DYNAWO_USE_XSD_VALIDATION=true
       ;;
     unittest-gdb)
+      export RDMAV_FORK_SAFE="1"
       export_var_env_force DYNAWO_BUILD_TYPE=Debug
       export_var_env_force DYNAWO_BUILD_TESTS=ON
       export_var_env_force DYNAWO_BUILD_TESTS_COVERAGE=OFF


### PR DESCRIPTION
As far as I can see, DYNSimulation::init() has subcalls to fork(), through either boost or omc.
This conflicts with the default optimized mode of libfabric, needed by MPI in dyn-algo.
 Setting the RDMAV_FORK_SAFE to 1 when running in unittests mode appears to solve the problem by adopting a slower but safer mode of process memory use, and should not cause external issues as this is circumscribed to unit testing in which MPI is unused anyway.
More worrisome is the absence of this warning in actual production modes where both MPI and dynawo could in theory actually be in conflict, but this does not affect this issue.
